### PR TITLE
Upgrades to latest sbt-org-policies version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val `sbt-freestyle` = project
   .in(file("."))
   .settings(name := "sbt-freestyle")
   .settings(Seq(
-    addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.5.11"),
+    addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.5.12"),
     sbtPlugin := true,
     description := "sbt-plugin for Freestyle projects",
     startYear := Option(2017),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.5.11")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.5.12")

--- a/src/main/scala/freestyle/FreestylePlugin.scala
+++ b/src/main/scala/freestyle/FreestylePlugin.scala
@@ -139,7 +139,7 @@ object FreestylePlugin extends AutoPlugin {
         TravisFileType(crossScalaVersions.value, orgScriptCICommandKey, orgAfterCISuccessCommandKey)
       ),
       // format: ON
-      orgSupportedScalaJSVersion := Some("0.6.15"),
+      orgSupportedScalaJSVersion := Some("0.6.18"),
       orgScriptTaskListSetting := List(
         (clean in Global).asRunnableItemFull,
         SetSetting(coverageEnabled in Global, true).asRunnableItem,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.3-SNAPSHOT"
+version in ThisBuild := "0.1.3"


### PR DESCRIPTION
The new version of `sbt-freestyle` will use, from now on, scalajs `0.6.18`.