### PR TITLE
Upgrades sbt-org-policies 0.8.6

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.5")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.6")

--- a/src/main/scala/freestyle/FreestylePlugin.scala
+++ b/src/main/scala/freestyle/FreestylePlugin.scala
@@ -24,11 +24,11 @@ import sbt._
 import sbtorgpolicies.OrgPoliciesKeys.orgBadgeListSetting
 import sbtorgpolicies.OrgPoliciesPlugin
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
-import sbtorgpolicies.model._
 import sbtorgpolicies.runnable.SetSetting
 import sbtorgpolicies.templates._
 import sbtorgpolicies.templates.badges._
 import sbtorgpolicies.runnable.syntax._
+import sbtorgpolicies.model._
 import scoverage.ScoverageKeys
 import scoverage.ScoverageKeys._
 
@@ -152,6 +152,8 @@ object FreestylePlugin extends AutoPlugin {
         scalaBinaryVersion.value == "2.12" && ((baseDirectory in LocalRootProject).value / "docs")
           .exists())("docs/tut".asRunnableItem),
       resolvers += Resolver.sonatypeRepo("snapshots"),
+      scalaVersion := "2.12.3",
+      crossScalaVersions := Seq(scalac.`2.11`, "2.12.3"),
       scalacOptions ++= scalacAdvancedOptions,
       scalacOptions ~= (_ filterNot Set("-Yliteral-types", "-Xlint").contains),
       parallelExecution in Test := false,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.7-SNAPSHOT"
+version in ThisBuild := "0.3.7"


### PR DESCRIPTION
By default, all projects using `sbt-freestyle` will use scala `2.12.3` and they will be cross-versioned with scala `2.11.11`.