### PR TITLE
Upgrades to sbt-org-policies 0.8.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
   include:
     - scala: 2.12.4
       env:
-        - SBT_VERSION=1.0.2
-    - scala: 2.10.6
+        - SBT_VERSION=1.0.3
+    - scala: 2.10.7
       env:
         - SBT_VERSION=0.13.16
 
@@ -43,7 +43,7 @@ after_success:
     if grep -q "SNAPSHOT" version.sbt; then
       sbt ^^$SBT_VERSION publish;
     else
-      if [ "$SBT_VERSION" = "1.0.2" ]; then
+      if [ "$SBT_VERSION" = "1.0.3" ]; then
         sbt ^^$SBT_VERSION orgUpdateDocFiles;
         git reset --hard HEAD;
         git clean -f;

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.2
+sbt.version = 1.0.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.10")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.15")

--- a/src/main/scala/freestyle/FreestylePlugin.scala
+++ b/src/main/scala/freestyle/FreestylePlugin.scala
@@ -64,7 +64,8 @@ object FreestylePlugin extends AutoPlugin {
         "gray-light"      -> "#E6E7EC",
         "gray-lighter"    -> "#F4F5F9",
         "white-color"     -> "#E6E7EC"
-      )
+      ),
+      micrositePushSiteWith := GitHub4s
     )
 
     lazy val commonDeps: Seq[ModuleID] = Seq(%%("scalatest") % "test")

--- a/src/main/scala/freestyle/FreestylePlugin.scala
+++ b/src/main/scala/freestyle/FreestylePlugin.scala
@@ -153,8 +153,8 @@ object FreestylePlugin extends AutoPlugin {
         scalaBinaryVersion.value == "2.12" && ((baseDirectory in LocalRootProject).value / "docs")
           .exists())("docs/tut".asRunnableItem),
       resolvers += Resolver.sonatypeRepo("snapshots"),
-      scalaVersion := "2.12.3",
-      crossScalaVersions := Seq(scalac.`2.11`, "2.12.3"),
+      scalaVersion := scalac.`2.12`,
+      crossScalaVersions := Seq(scalac.`2.11`, scalac.`2.12`),
       scalacOptions ++= scalacAdvancedOptions,
       scalacOptions ~= (_ filterNot Set("-Yliteral-types", "-Xlint").contains),
       parallelExecution in Test := false,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.11-SNAPSHOT"
+version in ThisBuild := "0.3.11"


### PR DESCRIPTION
Upgrades to sbt `1.0.3`, and makes that the default method to publish the microsite would be `Github4s`, instead of the GHPagesPlugin.