### PR TITLE
Upgrade to the latest sbt-org-policies version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ jdk:
 
 matrix:
   include:
-    - scala: 2.12.4
+    - scala: 2.12.6
       env:
-        - SBT_VERSION=1.1.1
+        - SBT_VERSION=1.2.1
     - scala: 2.10.7
       env:
         - SBT_VERSION=0.13.17
@@ -43,7 +43,7 @@ after_success:
     if grep -q "SNAPSHOT" version.sbt; then
       sbt ^^$SBT_VERSION publish;
     else
-      if [ "$SBT_VERSION" = "1.1.1" ]; then
+      if [ "$SBT_VERSION" = "1.2.1" ]; then
         sbt ^^$SBT_VERSION orgUpdateDocFiles;
         git reset --hard HEAD;
         git clean -f;

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.1
+sbt.version = 1.2.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.sonatypeRepo("releases")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.9.1")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.9.3")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.24-SNAPSHOT"
+version in ThisBuild := "0.3.24"


### PR DESCRIPTION
Transitively will upgrade libraries and plugins (sbt-release, sbt-scalajs, etc.).
It also:

* Updates to sbt 1.2.1.
* Releases sbt-freestyle 0.3.24.